### PR TITLE
ci: update release-please action from v4 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     
       - name: Prepare GitHub release
         id: create_prod_release
-        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         if: github.ref == 'refs/heads/main'
         with:
           skip-github-pull-request: true
@@ -48,7 +48,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD  }}
           
       - name: Prepare release PR
-        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v4@main
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         if: github.ref == 'refs/heads/main'
         with:
           skip-github-release: true


### PR DESCRIPTION
Updates the googleapis/release-please-action reference in the CI workflow from v4 to v5.